### PR TITLE
Fix base image to add support for ARM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.11-slim
+FROM node:8.11
 
 # crafted and tuned by pierre@ozoux.net and sing.li@rocket.chat
 MAINTAINER buildmaster@rocket.chat


### PR DESCRIPTION
While trying to build Rocket.chat for ARM64 we found the Fibers package missing. There is a prebuilt Fibers package for x64, but it has to be built from source on arm64. However, the build fails with -slim node image from which some tools like python are missing.

Therefore we request the Rocket.chat project switch to using the non slim version of node image.

The issue was reported earlier here : https://github.com/RocketChat/Docker.Official.Image/issues/48